### PR TITLE
feat(v0.6): exercises form slim (name+group only) + plan-exercise ful…

### DIFF
--- a/lib/src/data/db/app_database.dart
+++ b/lib/src/data/db/app_database.dart
@@ -41,6 +41,7 @@ class PlanExercises extends Table {
   IntColumn get repMax => integer().withDefault(const Constant(8))();
   RealColumn get weightStep => real().withDefault(const Constant(2.5))();
   RealColumn get initialWeight => real().nullable()();
+  TextColumn get notes => text().nullable()();
 
   @override
   List<String> get customConstraints => [
@@ -108,11 +109,10 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.test() : super(NativeDatabase.memory());
 
   @override
-  int get schemaVersion => 1;
+  int get schemaVersion => 2;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
-    // FK-Constraints auf JEDER Connection aktivieren (auch In-Memory bei Tests)
     beforeOpen: (details) async {
       await customStatement('PRAGMA foreign_keys = ON');
     },
@@ -121,7 +121,10 @@ class AppDatabase extends _$AppDatabase {
       await _seedData(this);
     },
     onUpgrade: (m, from, to) async {
-      // zukünftige Migrationen
+      if (from < 2) {
+        // RAW SQL: Spalte 'notes' zu plan_exercises hinzufügen
+        await customStatement('ALTER TABLE plan_exercises ADD COLUMN notes TEXT;');
+      }
     },
   );
 }

--- a/lib/src/data/db/app_database.g.dart
+++ b/lib/src/data/db/app_database.g.dart
@@ -792,6 +792,11 @@ class $PlanExercisesTable extends PlanExercises
   late final GeneratedColumn<double> initialWeight = GeneratedColumn<double>(
       'initial_weight', aliasedName, true,
       type: DriftSqlType.double, requiredDuringInsert: false);
+  static const VerificationMeta _notesMeta = const VerificationMeta('notes');
+  @override
+  late final GeneratedColumn<String> notes = GeneratedColumn<String>(
+      'notes', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
   @override
   List<GeneratedColumn> get $columns => [
         id,
@@ -802,7 +807,8 @@ class $PlanExercisesTable extends PlanExercises
         repMin,
         repMax,
         weightStep,
-        initialWeight
+        initialWeight,
+        notes
       ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -859,6 +865,10 @@ class $PlanExercisesTable extends PlanExercises
           initialWeight.isAcceptableOrUnknown(
               data['initial_weight']!, _initialWeightMeta));
     }
+    if (data.containsKey('notes')) {
+      context.handle(
+          _notesMeta, notes.isAcceptableOrUnknown(data['notes']!, _notesMeta));
+    }
     return context;
   }
 
@@ -886,6 +896,8 @@ class $PlanExercisesTable extends PlanExercises
           .read(DriftSqlType.double, data['${effectivePrefix}weight_step'])!,
       initialWeight: attachedDatabase.typeMapping
           .read(DriftSqlType.double, data['${effectivePrefix}initial_weight']),
+      notes: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}notes']),
     );
   }
 
@@ -905,6 +917,7 @@ class PlanExercise extends DataClass implements Insertable<PlanExercise> {
   final int repMax;
   final double weightStep;
   final double? initialWeight;
+  final String? notes;
   const PlanExercise(
       {required this.id,
       required this.planId,
@@ -914,7 +927,8 @@ class PlanExercise extends DataClass implements Insertable<PlanExercise> {
       required this.repMin,
       required this.repMax,
       required this.weightStep,
-      this.initialWeight});
+      this.initialWeight,
+      this.notes});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -928,6 +942,9 @@ class PlanExercise extends DataClass implements Insertable<PlanExercise> {
     map['weight_step'] = Variable<double>(weightStep);
     if (!nullToAbsent || initialWeight != null) {
       map['initial_weight'] = Variable<double>(initialWeight);
+    }
+    if (!nullToAbsent || notes != null) {
+      map['notes'] = Variable<String>(notes);
     }
     return map;
   }
@@ -945,6 +962,8 @@ class PlanExercise extends DataClass implements Insertable<PlanExercise> {
       initialWeight: initialWeight == null && nullToAbsent
           ? const Value.absent()
           : Value(initialWeight),
+      notes:
+          notes == null && nullToAbsent ? const Value.absent() : Value(notes),
     );
   }
 
@@ -961,6 +980,7 @@ class PlanExercise extends DataClass implements Insertable<PlanExercise> {
       repMax: serializer.fromJson<int>(json['repMax']),
       weightStep: serializer.fromJson<double>(json['weightStep']),
       initialWeight: serializer.fromJson<double?>(json['initialWeight']),
+      notes: serializer.fromJson<String?>(json['notes']),
     );
   }
   @override
@@ -976,6 +996,7 @@ class PlanExercise extends DataClass implements Insertable<PlanExercise> {
       'repMax': serializer.toJson<int>(repMax),
       'weightStep': serializer.toJson<double>(weightStep),
       'initialWeight': serializer.toJson<double?>(initialWeight),
+      'notes': serializer.toJson<String?>(notes),
     };
   }
 
@@ -988,7 +1009,8 @@ class PlanExercise extends DataClass implements Insertable<PlanExercise> {
           int? repMin,
           int? repMax,
           double? weightStep,
-          Value<double?> initialWeight = const Value.absent()}) =>
+          Value<double?> initialWeight = const Value.absent(),
+          Value<String?> notes = const Value.absent()}) =>
       PlanExercise(
         id: id ?? this.id,
         planId: planId ?? this.planId,
@@ -1000,6 +1022,7 @@ class PlanExercise extends DataClass implements Insertable<PlanExercise> {
         weightStep: weightStep ?? this.weightStep,
         initialWeight:
             initialWeight.present ? initialWeight.value : this.initialWeight,
+        notes: notes.present ? notes.value : this.notes,
       );
   PlanExercise copyWithCompanion(PlanExercisesCompanion data) {
     return PlanExercise(
@@ -1016,6 +1039,7 @@ class PlanExercise extends DataClass implements Insertable<PlanExercise> {
       initialWeight: data.initialWeight.present
           ? data.initialWeight.value
           : this.initialWeight,
+      notes: data.notes.present ? data.notes.value : this.notes,
     );
   }
 
@@ -1030,14 +1054,15 @@ class PlanExercise extends DataClass implements Insertable<PlanExercise> {
           ..write('repMin: $repMin, ')
           ..write('repMax: $repMax, ')
           ..write('weightStep: $weightStep, ')
-          ..write('initialWeight: $initialWeight')
+          ..write('initialWeight: $initialWeight, ')
+          ..write('notes: $notes')
           ..write(')'))
         .toString();
   }
 
   @override
   int get hashCode => Object.hash(id, planId, exerciseId, order, sets, repMin,
-      repMax, weightStep, initialWeight);
+      repMax, weightStep, initialWeight, notes);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -1050,7 +1075,8 @@ class PlanExercise extends DataClass implements Insertable<PlanExercise> {
           other.repMin == this.repMin &&
           other.repMax == this.repMax &&
           other.weightStep == this.weightStep &&
-          other.initialWeight == this.initialWeight);
+          other.initialWeight == this.initialWeight &&
+          other.notes == this.notes);
 }
 
 class PlanExercisesCompanion extends UpdateCompanion<PlanExercise> {
@@ -1063,6 +1089,7 @@ class PlanExercisesCompanion extends UpdateCompanion<PlanExercise> {
   final Value<int> repMax;
   final Value<double> weightStep;
   final Value<double?> initialWeight;
+  final Value<String?> notes;
   const PlanExercisesCompanion({
     this.id = const Value.absent(),
     this.planId = const Value.absent(),
@@ -1073,6 +1100,7 @@ class PlanExercisesCompanion extends UpdateCompanion<PlanExercise> {
     this.repMax = const Value.absent(),
     this.weightStep = const Value.absent(),
     this.initialWeight = const Value.absent(),
+    this.notes = const Value.absent(),
   });
   PlanExercisesCompanion.insert({
     this.id = const Value.absent(),
@@ -1084,6 +1112,7 @@ class PlanExercisesCompanion extends UpdateCompanion<PlanExercise> {
     this.repMax = const Value.absent(),
     this.weightStep = const Value.absent(),
     this.initialWeight = const Value.absent(),
+    this.notes = const Value.absent(),
   })  : planId = Value(planId),
         exerciseId = Value(exerciseId);
   static Insertable<PlanExercise> custom({
@@ -1096,6 +1125,7 @@ class PlanExercisesCompanion extends UpdateCompanion<PlanExercise> {
     Expression<int>? repMax,
     Expression<double>? weightStep,
     Expression<double>? initialWeight,
+    Expression<String>? notes,
   }) {
     return RawValuesInsertable({
       if (id != null) 'id': id,
@@ -1107,6 +1137,7 @@ class PlanExercisesCompanion extends UpdateCompanion<PlanExercise> {
       if (repMax != null) 'rep_max': repMax,
       if (weightStep != null) 'weight_step': weightStep,
       if (initialWeight != null) 'initial_weight': initialWeight,
+      if (notes != null) 'notes': notes,
     });
   }
 
@@ -1119,7 +1150,8 @@ class PlanExercisesCompanion extends UpdateCompanion<PlanExercise> {
       Value<int>? repMin,
       Value<int>? repMax,
       Value<double>? weightStep,
-      Value<double?>? initialWeight}) {
+      Value<double?>? initialWeight,
+      Value<String?>? notes}) {
     return PlanExercisesCompanion(
       id: id ?? this.id,
       planId: planId ?? this.planId,
@@ -1130,6 +1162,7 @@ class PlanExercisesCompanion extends UpdateCompanion<PlanExercise> {
       repMax: repMax ?? this.repMax,
       weightStep: weightStep ?? this.weightStep,
       initialWeight: initialWeight ?? this.initialWeight,
+      notes: notes ?? this.notes,
     );
   }
 
@@ -1163,6 +1196,9 @@ class PlanExercisesCompanion extends UpdateCompanion<PlanExercise> {
     if (initialWeight.present) {
       map['initial_weight'] = Variable<double>(initialWeight.value);
     }
+    if (notes.present) {
+      map['notes'] = Variable<String>(notes.value);
+    }
     return map;
   }
 
@@ -1177,7 +1213,8 @@ class PlanExercisesCompanion extends UpdateCompanion<PlanExercise> {
           ..write('repMin: $repMin, ')
           ..write('repMax: $repMax, ')
           ..write('weightStep: $weightStep, ')
-          ..write('initialWeight: $initialWeight')
+          ..write('initialWeight: $initialWeight, ')
+          ..write('notes: $notes')
           ..write(')'))
         .toString();
   }
@@ -2824,6 +2861,7 @@ typedef $$PlanExercisesTableCreateCompanionBuilder = PlanExercisesCompanion
   Value<int> repMax,
   Value<double> weightStep,
   Value<double?> initialWeight,
+  Value<String?> notes,
 });
 typedef $$PlanExercisesTableUpdateCompanionBuilder = PlanExercisesCompanion
     Function({
@@ -2836,6 +2874,7 @@ typedef $$PlanExercisesTableUpdateCompanionBuilder = PlanExercisesCompanion
   Value<int> repMax,
   Value<double> weightStep,
   Value<double?> initialWeight,
+  Value<String?> notes,
 });
 
 final class $$PlanExercisesTableReferences
@@ -2917,6 +2956,9 @@ class $$PlanExercisesTableFilterComposer
 
   ColumnFilters<double> get initialWeight => $composableBuilder(
       column: $table.initialWeight, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get notes => $composableBuilder(
+      column: $table.notes, builder: (column) => ColumnFilters(column));
 
   $$PlansTableFilterComposer get planId {
     final $$PlansTableFilterComposer composer = $composerBuilder(
@@ -3011,6 +3053,9 @@ class $$PlanExercisesTableOrderingComposer
       column: $table.initialWeight,
       builder: (column) => ColumnOrderings(column));
 
+  ColumnOrderings<String> get notes => $composableBuilder(
+      column: $table.notes, builder: (column) => ColumnOrderings(column));
+
   $$PlansTableOrderingComposer get planId {
     final $$PlansTableOrderingComposer composer = $composerBuilder(
         composer: this,
@@ -3081,6 +3126,9 @@ class $$PlanExercisesTableAnnotationComposer
 
   GeneratedColumn<double> get initialWeight => $composableBuilder(
       column: $table.initialWeight, builder: (column) => column);
+
+  GeneratedColumn<String> get notes =>
+      $composableBuilder(column: $table.notes, builder: (column) => column);
 
   $$PlansTableAnnotationComposer get planId {
     final $$PlansTableAnnotationComposer composer = $composerBuilder(
@@ -3177,6 +3225,7 @@ class $$PlanExercisesTableTableManager extends RootTableManager<
             Value<int> repMax = const Value.absent(),
             Value<double> weightStep = const Value.absent(),
             Value<double?> initialWeight = const Value.absent(),
+            Value<String?> notes = const Value.absent(),
           }) =>
               PlanExercisesCompanion(
             id: id,
@@ -3188,6 +3237,7 @@ class $$PlanExercisesTableTableManager extends RootTableManager<
             repMax: repMax,
             weightStep: weightStep,
             initialWeight: initialWeight,
+            notes: notes,
           ),
           createCompanionCallback: ({
             Value<int> id = const Value.absent(),
@@ -3199,6 +3249,7 @@ class $$PlanExercisesTableTableManager extends RootTableManager<
             Value<int> repMax = const Value.absent(),
             Value<double> weightStep = const Value.absent(),
             Value<double?> initialWeight = const Value.absent(),
+            Value<String?> notes = const Value.absent(),
           }) =>
               PlanExercisesCompanion.insert(
             id: id,
@@ -3210,6 +3261,7 @@ class $$PlanExercisesTableTableManager extends RootTableManager<
             repMax: repMax,
             weightStep: weightStep,
             initialWeight: initialWeight,
+            notes: notes,
           ),
           withReferenceMapper: (p0) => p0
               .map((e) => (

--- a/lib/src/presentation/exercises/exercise_form_page.dart
+++ b/lib/src/presentation/exercises/exercise_form_page.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:drift/drift.dart' show Value;
 import '../../data/db/app_database.dart';
 import '../../data/db/db_provider.dart';
-import 'package:drift/drift.dart' show Value;
 
 class ExerciseFormPage extends ConsumerStatefulWidget {
   final Exercise? edit;
@@ -16,10 +16,6 @@ class _ExerciseFormPageState extends ConsumerState<ExerciseFormPage> {
   final _form = GlobalKey<FormState>();
   final _name = TextEditingController();
   final _group = TextEditingController();
-  final _step = TextEditingController(text: '2.5');
-  final _repMin = TextEditingController(text: '5');
-  final _repMax = TextEditingController(text: '8');
-  final _notes = TextEditingController();
 
   @override
   void initState() {
@@ -28,10 +24,6 @@ class _ExerciseFormPageState extends ConsumerState<ExerciseFormPage> {
     if (e != null) {
       _name.text = e.name;
       _group.text = e.group ?? '';
-      _step.text = e.defaultWeightStep.toString();
-      _repMin.text = e.defaultRepMin.toString();
-      _repMax.text = e.defaultRepMax.toString();
-      _notes.text = e.notes ?? '';
     }
   }
 
@@ -57,38 +49,6 @@ class _ExerciseFormPageState extends ConsumerState<ExerciseFormPage> {
               controller: _group,
               decoration: const InputDecoration(labelText: 'Gruppe (optional)'),
             ),
-            TextFormField(
-              controller: _step,
-              decoration: const InputDecoration(labelText: 'Gewichtsschritt (kg)'),
-              keyboardType: const TextInputType.numberWithOptions(decimal: true),
-              validator: (v) => (double.tryParse(v ?? '') == null) ? 'Zahl nötig' : null,
-            ),
-            Row(
-              children: [
-                Expanded(
-                  child: TextFormField(
-                    controller: _repMin,
-                    decoration: const InputDecoration(labelText: 'Rep min'),
-                    keyboardType: TextInputType.number,
-                    validator: (v) => (int.tryParse(v ?? '') == null) ? 'Zahl nötig' : null,
-                  ),
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: TextFormField(
-                    controller: _repMax,
-                    decoration: const InputDecoration(labelText: 'Rep max'),
-                    keyboardType: TextInputType.number,
-                    validator: (v) => (int.tryParse(v ?? '') == null) ? 'Zahl nötig' : null,
-                  ),
-                ),
-              ],
-            ),
-            TextFormField(
-              controller: _notes,
-              decoration: const InputDecoration(labelText: 'Notizen'),
-              maxLines: 3,
-            ),
             const SizedBox(height: 20),
             FilledButton.icon(
               key: const Key('btn-save-exercise'),
@@ -96,10 +56,6 @@ class _ExerciseFormPageState extends ConsumerState<ExerciseFormPage> {
                 if (!_form.currentState!.validate()) return;
                 final name = _name.text.trim();
                 final group = _group.text.trim().isEmpty ? null : _group.text.trim();
-                final step = double.parse(_step.text);
-                final repMin = int.parse(_repMin.text);
-                final repMax = int.parse(_repMax.text);
-                final notes = _notes.text.trim().isEmpty ? null : _notes.text.trim();
 
                 if (isEdit) {
                   await ExercisesDao(db).updateById(
@@ -107,10 +63,6 @@ class _ExerciseFormPageState extends ConsumerState<ExerciseFormPage> {
                     ExercisesCompanion(
                       name: Value(name),
                       group: Value(group),
-                      defaultWeightStep: Value(step),
-                      defaultRepMin: Value(repMin),
-                      defaultRepMax: Value(repMax),
-                      notes: Value(notes),
                     ),
                   );
                 } else {
@@ -118,10 +70,6 @@ class _ExerciseFormPageState extends ConsumerState<ExerciseFormPage> {
                     ExercisesCompanion.insert(
                       name: name,
                       group: Value(group),
-                      defaultWeightStep: Value(step),
-                      defaultRepMin: Value(repMin),
-                      defaultRepMax: Value(repMax),
-                      notes: Value(notes),
                     ),
                   );
                 }

--- a/lib/src/presentation/plans/plan_editor_page.dart
+++ b/lib/src/presentation/plans/plan_editor_page.dart
@@ -16,13 +16,12 @@ class PlanEditorPage extends ConsumerWidget {
 
     return Scaffold(
       appBar: AppBar(title: const Text('Plan bearbeiten')),
-      body: StreamBuilder<List<PlanExercise>>( // ← live updates
+      body: StreamBuilder<List<PlanExercise>>(
         stream: peDao.watchByPlan(planId),
         builder: (context, snap) {
           if (!snap.hasData) return const Center(child: CircularProgressIndicator());
           final planExercises = snap.data!;
-
-          return FutureBuilder<List<Exercise>>( // Übungsnamen laden
+          return FutureBuilder<List<Exercise>>(
             future: exDao.all(),
             builder: (context, exSnap) {
               if (!exSnap.hasData) return const Center(child: CircularProgressIndicator());
@@ -38,34 +37,89 @@ class PlanEditorPage extends ConsumerWidget {
                         child: OutlinedButton.icon(
                           key: const Key('btn-add-plan-exercise'),
                           onPressed: () async {
-                            // Alphabetische Auswahl
+                            // 1) Übung wählen (alphabetisch)
                             final sorted = [...exercises]
                               ..sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
-
                             final chosen = await showDialog<Exercise>(
                               context: context,
                               builder: (_) => SimpleDialog(
-                                title: const Text('Übung hinzufügen'),
+                                title: const Text('Übung wählen'),
                                 children: sorted
                                     .map((e) => SimpleDialogOption(
-                                          onPressed: () => Navigator.pop(context, e),
-                                          child: Text(e.name),
-                                        ))
+                                  onPressed: () => Navigator.pop(context, e),
+                                  child: Text(e.name),
+                                ))
                                     .toList(),
                               ),
                             );
                             if (chosen == null) return;
 
-                            // Startgewicht abfragen (Default 20 kg)
-                            final ctrl = TextEditingController(text: '20');
+                            // 2) Konfiguration erfassen
+                            final setsCtrl = TextEditingController(text: '3');
+                            final repMinCtrl = TextEditingController(text: '5');
+                            final repMaxCtrl = TextEditingController(text: '8');
+                            final stepCtrl = TextEditingController(text: '2.5');
+                            final initCtrl = TextEditingController(text: '20');
+                            final notesCtrl = TextEditingController();
+
                             final ok = await showDialog<bool>(
                               context: context,
                               builder: (_) => AlertDialog(
-                                title: Text('Startgewicht für ${chosen.name}'),
-                                content: TextField(
-                                  controller: ctrl,
-                                  keyboardType: const TextInputType.numberWithOptions(decimal: true),
-                                  decoration: const InputDecoration(labelText: 'kg'),
+                                title: Text('Einstellungen – ${chosen.name}'),
+                                content: SingleChildScrollView(
+                                  child: Column(
+                                    mainAxisSize: MainAxisSize.min,
+                                    children: [
+                                      Row(
+                                        children: [
+                                          Expanded(
+                                            child: TextField(
+                                              controller: setsCtrl,
+                                              keyboardType: TextInputType.number,
+                                              decoration: const InputDecoration(labelText: 'Sätze'),
+                                            ),
+                                          ),
+                                          const SizedBox(width: 8),
+                                          Expanded(
+                                            child: TextField(
+                                              controller: stepCtrl,
+                                              keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                                              decoration: const InputDecoration(labelText: 'Gewichtsschritt (kg)'),
+                                            ),
+                                          ),
+                                        ],
+                                      ),
+                                      Row(
+                                        children: [
+                                          Expanded(
+                                            child: TextField(
+                                              controller: repMinCtrl,
+                                              keyboardType: TextInputType.number,
+                                              decoration: const InputDecoration(labelText: 'Rep min'),
+                                            ),
+                                          ),
+                                          const SizedBox(width: 8),
+                                          Expanded(
+                                            child: TextField(
+                                              controller: repMaxCtrl,
+                                              keyboardType: TextInputType.number,
+                                              decoration: const InputDecoration(labelText: 'Rep max'),
+                                            ),
+                                          ),
+                                        ],
+                                      ),
+                                      TextField(
+                                        controller: initCtrl,
+                                        keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                                        decoration: const InputDecoration(labelText: 'Startgewicht (kg)'),
+                                      ),
+                                      TextField(
+                                        controller: notesCtrl,
+                                        decoration: const InputDecoration(labelText: 'Notizen (optional)'),
+                                        maxLines: 3,
+                                      ),
+                                    ],
+                                  ),
                                 ),
                                 actions: [
                                   TextButton(onPressed: () => Navigator.pop(context, false), child: const Text('Abbrechen')),
@@ -74,17 +128,24 @@ class PlanEditorPage extends ConsumerWidget {
                               ),
                             );
                             if (ok != true) return;
-                            final initW = double.tryParse(ctrl.text) ?? 20;
+
+                            final sets = int.tryParse(setsCtrl.text) ?? 3;
+                            final repMin = int.tryParse(repMinCtrl.text) ?? 5;
+                            final repMax = int.tryParse(repMaxCtrl.text) ?? 8;
+                            final step = double.tryParse(stepCtrl.text) ?? 2.5;
+                            final init = double.tryParse(initCtrl.text) ?? 20;
+                            final notes = notesCtrl.text.trim().isEmpty ? null : notesCtrl.text.trim();
 
                             await peDao.add(PlanExercisesCompanion.insert(
                               planId: planId,
                               exerciseId: chosen.id,
                               order: const Value(1),
-                              sets: const Value(3),
-                              repMin: const Value(5),
-                              repMax: const Value(8),
-                              weightStep: const Value(2.5),
-                              initialWeight: Value(initW),
+                              sets: Value(sets),
+                              repMin: Value(repMin),
+                              repMax: Value(repMax),
+                              weightStep: Value(step),
+                              initialWeight: Value(init),
+                              notes: Value(notes),
                             ));
                           },
                           icon: const Icon(Icons.add),
@@ -103,7 +164,13 @@ class PlanEditorPage extends ConsumerWidget {
                       return Card(
                         child: ListTile(
                           title: Text('$title • ${pe.sets} Sätze • ${pe.repMin}-${pe.repMax} Wdh • Step ${pe.weightStep}'),
-                          subtitle: Text('Start: ${(pe.initialWeight ?? 0).toStringAsFixed(1)} kg • Reihenfolge: ${pe.order}'),
+                          subtitle: Text(
+                            [
+                              'Start: ${(pe.initialWeight ?? 0).toStringAsFixed(1)} kg',
+                              'Reihenfolge: ${pe.order}',
+                              if ((pe.notes ?? '').isNotEmpty) 'Notizen: ${pe.notes}',
+                            ].join(' • '),
+                          ),
                           trailing: IconButton(
                             icon: const Icon(Icons.delete),
                             onPressed: () async {


### PR DESCRIPTION
…l config (sets, rep-range, weight step, start weight, notes) with migration v2

DB: PlanExercises.notes added; schema v2 + onUpgrade migration.
UI: Exercise form simplified; Plan editor collects full config on add; listing shows exercise name + details.

16/09/25 23:04
-running